### PR TITLE
fix rebar.config deps

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-	{cowlib, ".*", {git, "https://github.com/kojingharang/cowlib.git", "1.0.0_otp20fix"}},
-	{ranch, ".*", {git, "https://github.com/extend/ranch.git", "1.0.0"}}
+	{cowlib,     {git, "https://github.com/kojingharang/cowlib.git", {tag, "1.0.0_otp20fix"}}},
+	{ranch,      {git, "https://github.com/ninenines/ranch.git", {tag, "1.0.0"}}}
 ]}.


### PR DESCRIPTION
Change git URL of ranch to point ninenines instead of old extend.
Porting it to rebar3